### PR TITLE
Warning Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,21 @@ Karma-eslint accepts these options:
 
 > `stopOnWarning`
 > - fails a test on any Warning *default: `false`*
+> - if set `true`, Warnings are always displayed
+
+
+> `showWarnings`
+> - to display Warning messages *default: `true`*
+> - has no effect if `stopOnWarning` is set `true`
+> - in such case Warnings are displayed anyway
 
 Example:
 
 ```javascript
   eslint: {
-    stopOnError: false,
-    stopOnWarning: true
+	stopOnError: true,
+	stopOnWarning: false,
+	showWarnings: true
   }
 ```
 

--- a/index.js
+++ b/index.js
@@ -34,18 +34,13 @@
       };
 
       results.forEach(function(result) {
-        if(result.errorCount === 1) {
-          log.error('\n' +
-            chalk.red(result.filePath) + '\n' +
-            getError(result.messages[0]) + '\n\n'
-          );
-        } else if(result.errorCount > 0) {
+	  if(result.errorCount > 0) {
           var errors = [];
           result.messages.forEach(function(message) {
             errors.push(getError(message));
           });
           log.error('\n' +
-            chalk.red(result.errorCount + ' errors in ' + result.filePath) + '\n' +
+            chalk.red(result.errorCount + ' error(s) in ' + result.filePath) + '\n' +
             errors.join('\n') + '\n\n'
           );
         }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@
     var eslintPreprocessorConfig = config.eslint;
     var log = loggerFactory.create('preprocessor.eslint');
     var options = {
+      showWarnings: getOptionWithFallback('showWarnings', true),
       stopOnError: getOptionWithFallback('stopOnError', true),
       stopOnWarning: getOptionWithFallback('stopOnWarning', false)
     };
@@ -49,8 +50,37 @@
       });
     }
 
+    function processWarnings(results) {
+      var getWarning = function(message) {
+        var rule = (message.ruleId) ?
+          ' Rule: ' + message.ruleId :
+          '';
+
+        return chalk.yellow('   - ' + message.line + ':' + message.column + ' ' + message.message) +
+               chalk.green(rule);
+      };
+
+      results.forEach(function(result) {
+	  if(result.warningCount > 0) {
+          var warnings = [];
+          result.messages.forEach(function(message) {
+	      if(message.severity === 1){
+		  warnings.push(getWarning(message));
+	      }
+          });
+          log.warn('\n' +
+            chalk.yellow(result.warningCount + ' warning(s) in ' + result.filePath) + '\n' +
+            warnings.join('\n') + '\n\n'
+          );
+        }
+      });
+    }
+
     function shouldStop(report) {
-      if(report.errorCount || report.warningCount) processErrors(report.results);
+      if(report.warningCount && 
+	 (options.showWarnings || options.stopOnWarning)) 
+	  processWarnings(report.results);
+      if(report.errorCount) processErrors(report.results);
       return (report.errorCount && options.stopOnError) ||
         (report.warningCount && options.stopOnWarning);
     }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,9 @@
 	  if(result.errorCount > 0) {
           var errors = [];
           result.messages.forEach(function(message) {
-            errors.push(getError(message));
+	      if(message.severity > 1){
+		  errors.push(getError(message));
+	      }
           });
           log.error('\n' +
             chalk.red(result.errorCount + ' error(s) in ' + result.filePath) + '\n' +


### PR DESCRIPTION
- allows displaying warning messages (severity === 1) separately of error messages
- warning messages are not mixed with error messages anymore
- warning messages can be displayed even when no error message appears
- warning messages are displayed with _yellow_ text
- new option `showWarnings` was added to _enable_ / _disable_ displaying of Warning messages
- if `stopOnWarning` is set _true_, warning messages are always displayed, no matter of `showWarnings` setting
