### PR TITLE
Add error threshold options to stop build early

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ Karma-eslint accepts these options:
 > `stopOnError`
 > - fails a test on any error *default: `true`*
 
+> `errorThreshold`
+> - a threshold value for total errors *default: `null`*
+> - use with `stopAboveErrorThreshold` to stop build if errors exceed threshold
+
+> `stopAboveErrorThreshold`
+> - stops build if `errorThreshold` exceeded *default: `false`*
 
 > `stopOnWarning`
 > - fails a test on any Warning *default: `false`*
 > - if set `true`, Warnings are always displayed
-
 
 > `showWarnings`
 > - to display Warning messages *default: `true`*
@@ -44,6 +49,8 @@ Example:
 
 ```javascript
   eslint: {
+    errorThreshold: 1000,
+    stopAboveErrorThreshold: true,
     stopOnError: false,
     stopOnWarning: true,
     showWarnings: true,


### PR DESCRIPTION
I've made some changes to the package to allow some additional functionality I need for a project. 
Please let me know if you have any questions/concerns (or you just plain hate them).
Basically, I need to be able to configure karma to stop a build running if a total error threshold is exceeded.

* adds `errorThreshold` to set maximum allowed errors
* adds `stopAboveErrorThreshold` boolean to stop build if threshold
exceeded.