### PR TITLE
Add error tally reporting for use with stopAboveThreshold 

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,15 +93,24 @@
         (report.warningCount && options.stopOnWarning);
     }
 
+    function reportErrorTally() {
+      if(totalErrorCount > 0) {
+        log.warn(chalk.green('There are a total of ') +
+        chalk.white.bgRed(totalErrorCount) + chalk.green(' errors'));
+      }
+    }
+
     return function(content, file, done) {
       var report = cli.executeOnFiles([file.path]);
 
       log.debug('Processing "%s".', file.originalPath);
+      reportErrorTally();
+
       if(shouldStop(report)) {
         done(report.results);
       } else if(options.stopAboveErrorThreshold && totalErrorCount > options.errorThreshold) {
         log.error('\n' + chalk.red('There are more than ' + options.errorThreshold + ' errors'));
-        process.exit();
+        process.exit(1);
       } else {
         done(null, content);
       }


### PR DESCRIPTION
Hi,
 Thanks for accepting the last PR. 
I thought this a running tally of the total errors would also be useful for those wanting to set an error threshold. Setting this will allow them to configure the error threshold for their project and let them control when to fail the build.

I threw this together - let me know if you have any questions or suggestions. There might be a way to clean it up with only a single call to `reportErrorTally`.

Thanks,
Alex